### PR TITLE
Fix: ensure history file parent directory exists before saving

### DIFF
--- a/custom_components/tado_ce/api_call_tracker.py
+++ b/custom_components/tado_ce/api_call_tracker.py
@@ -69,6 +69,8 @@ class APICallTracker:
         
         # Ensure data directory exists
         self.data_dir.mkdir(parents=True, exist_ok=True)
+        # Also ensure parent directory of history file exists (may differ from data_dir)
+        self.history_file.parent.mkdir(parents=True, exist_ok=True)
     
     def _load_history_sync(self) -> Dict:
         """Load call history from disk synchronously."""
@@ -86,6 +88,8 @@ class APICallTracker:
         import shutil
         
         try:
+            # Ensure parent directory exists
+            self.history_file.parent.mkdir(parents=True, exist_ok=True)
             # Write to temp file first
             with tempfile.NamedTemporaryFile(
                 mode='w', dir=self.data_dir, delete=False, suffix='.tmp'
@@ -118,8 +122,8 @@ class APICallTracker:
     async def _save_history_async(self, data: Dict):
         """Save call history to disk using native async I/O with atomic write."""
         try:
-            # Ensure directory exists
-            await aiofiles.os.makedirs(self.data_dir, exist_ok=True)
+            # Ensure parent directory of history file exists
+            await aiofiles.os.makedirs(self.history_file.parent, exist_ok=True)
             
             # Write to temp file then atomic rename
             temp_path = self.history_file.with_suffix('.tmp')


### PR DESCRIPTION
## Problem

The API call tracker fails with `[Errno 2] No such file or directory` when trying to save call history. This happens because `get_data_file()` returns a path whose parent directory may not exist yet (e.g., in multi-home setups where the path includes a home-specific subdirectory).

```
Logger: custom_components.tado_ce.api_call_tracker
Source: custom_components/tado_ce/api_call_tracker.py:132
Failed to save API call history: [Errno 2] No such file or directory
```

## Root Cause

- `__init__` creates `self.data_dir` but not `self.history_file.parent`
- `_save_history_sync` writes a temp file to `self.data_dir` but the final file may be in a different directory
- `_save_history_async` ensures `self.data_dir` exists but should ensure `self.history_file.parent` instead

## Fix

1. **`__init__`**: Also create `self.history_file.parent` directory
2. **`_save_history_sync`**: Add `self.history_file.parent.mkdir(parents=True, exist_ok=True)` before writing
3. **`_save_history_async`**: Change `makedirs(self.data_dir)` to `makedirs(self.history_file.parent)` to create the correct directory

Closes #127