### PR TITLE
fix: HomeKit local-control sync gaps for heating state, mode, and target temperature

### DIFF
--- a/custom_components/tado_ce/climate_ac.py
+++ b/custom_components/tado_ce/climate_ac.py
@@ -1065,6 +1065,11 @@ class TadoACClimate(PerEntityAvailabilityMixin, CoordinatorEntity["TadoDataUpdat
         if local_success:
             self.coordinator.record_homekit_write_saved(self._zone_id)
             self._last_write_source = "homekit"
+            # Same protection as the cloud-success path below: without this
+            # stamp a stale/conflicting bridge echo during the protection
+            # window can overwrite the value we just wrote via HomeKit.
+            if self.coordinator.state_reconciler:
+                self.coordinator.state_reconciler.record_local_write(self._zone_id)
             self._schedule_cloud_verification()
             _LOGGER.debug(
                 "Climate AC: %s set target %s°C via HomeKit",

--- a/custom_components/tado_ce/climate_heating.py
+++ b/custom_components/tado_ce/climate_heating.py
@@ -174,17 +174,43 @@ class TadoClimate(PerEntityAvailabilityMixin, CoordinatorEntity["TadoDataUpdateC
         """Return the entity type tag for state-capture routing."""
         return self._entity_type
 
+    def _get_local_hvac_action(self) -> HVACAction | None:
+        """Return the bridge's live current-heating-state, if fresh and applicable.
+
+        None while OFF (hvac_mode already owns the OFF action) or when no
+        fresh local reading is available (bridge unpaired, disconnected,
+        or the cache has gone stale).
+        """
+        if self._attr_hvac_mode == HVACMode.OFF:
+            return None
+        reconciler = self.coordinator.state_reconciler
+        provider = self.coordinator.homekit_provider
+        if not (reconciler and provider and provider.is_connected):
+            return None
+        reconciler.local_provider = provider
+        return reconciler.get_zone_hvac_action(self._zone_id)
+
     def _calculate_hvac_action(self, target_temp: float | None = None) -> HVACAction:
         """Calculate hvac_action for heating zone.
 
-        Priority: OFF mode > optimistic target_temp > expected action >
-        heating_power > temperature-aware HEAT fallback > IDLE. The
-        target_temp branch must run before _expected_hvac_action so a
-        new optimistic update overrides a stale expected action.
+        Priority: OFF mode > local HomeKit current-heating-state (freshest
+        ground truth, pushed by the bridge in near real time) > optimistic
+        target_temp guess > expected action > heating_power > temperature-
+        aware HEAT fallback > IDLE. The target_temp branch must run before
+        _expected_hvac_action so a new optimistic update overrides a stale
+        expected action.
         """
         # OFF mode always returns OFF
         if self._attr_hvac_mode == HVACMode.OFF:
             return HVACAction.OFF
+
+        # The bridge's own current-heating-state reflects what the TRV/
+        # boiler is actually doing right now, so it outranks the optimistic
+        # guess below (which can't know whether the new target actually
+        # calls for heat).
+        local_action = self._get_local_hvac_action()
+        if local_action is not None:
+            return local_action
 
         # If target_temp is provided (optimistic call), assume HEATING
         # This MUST be checked before _expected_hvac_action to ensure new
@@ -335,6 +361,18 @@ class TadoClimate(PerEntityAvailabilityMixin, CoordinatorEntity["TadoDataUpdateC
             # schedule" (AUTO), so accepting it onto _attr_hvac_mode flapped
             # schedule-following hybrid zones. Mode derives from the
             # cloud poll only (_determine_api_hvac_mode reads the overlay type).
+
+            # HVAC action: the bridge's live current-heating-state is the
+            # freshest ground truth available, pushed in near real time
+            # instead of waiting on the cloud poll or the optimistic window.
+            local_action = self._get_local_hvac_action()
+            if local_action is not None and local_action != self._attr_hvac_action:
+                old_action = self._attr_hvac_action
+                self._attr_hvac_action = local_action
+                _LOGGER.debug(
+                    "Climate Heating: %s hvac_action %s → %s (source homekit)",
+                    self._zone_name, old_action, local_action,
+                )
 
         self.async_write_ha_state()
 
@@ -834,6 +872,13 @@ class TadoClimate(PerEntityAvailabilityMixin, CoordinatorEntity["TadoDataUpdateC
                 "Climate Heating: %s target set to %s°C via HomeKit",
                 self._zone_name, temperature,
             )
+            # Protect the fresh value from a stale/conflicting bridge echo
+            # (e.g. a TRV that hasn't finished applying a just-preceding
+            # mode switch): every other successful write path stamps this,
+            # this one was missing it, letting merge_zone_target_temperature
+            # accept a reverted reading back over the user's own write.
+            if self.coordinator.state_reconciler:
+                self.coordinator.state_reconciler.record_local_write(self._zone_id)
             heating_cycle_coordinator = self.coordinator.heating_cycle_coordinator
             if heating_cycle_coordinator:
                 await heating_cycle_coordinator.on_zone_update(
@@ -952,6 +997,76 @@ class TadoClimate(PerEntityAvailabilityMixin, CoordinatorEntity["TadoDataUpdateC
                 raise_on_failure=True,
             )
 
+    async def _try_homekit_hvac_mode_write(self, mode_value: int, mode_label: str) -> bool:
+        """Attempt a local HomeKit write of the target-heating-state characteristic.
+
+        Only tried when overlay mode is Tado Default (HomeKit writes don't
+        carry termination info) and the write-health circuit is closed.
+        Returns True on success; False means the caller should fall back
+        to the cloud API.
+        """
+        use_homekit = should_use_homekit_for_overlay(self.hass, self._zone_id, entry_id=self._entry_id)
+        write_tracker = self.coordinator.write_health_tracker
+        if not (
+            use_homekit
+            and self.coordinator.homekit_provider
+            and self.coordinator.homekit_provider.is_connected
+            and write_tracker is not None
+            and write_tracker.should_try_homekit()
+        ):
+            return False
+
+        import time as _time
+
+        self.coordinator._homekit_write_attempts += 1
+        t0 = _time.monotonic()
+        local_success = False
+        try:
+            local_success = await self.coordinator.homekit_provider.set_hvac_mode(
+                self._zone_id, mode_value,
+            )
+        except Exception:
+            _LOGGER.debug(
+                "Climate Heating: %s HomeKit %s write raised an exception, "
+                "falling back to cloud",
+                self._zone_name, mode_label, exc_info=True,
+            )
+        elapsed_ms = (_time.monotonic() - t0) * 1000
+        self.coordinator._homekit_write_latency_sum += elapsed_ms
+        self.coordinator._homekit_write_latency_count += 1
+        if local_success:
+            self.coordinator._homekit_write_successes += 1
+        else:
+            write_tracker.record_failure()
+            self.coordinator._homekit_write_fallbacks += 1
+            _LOGGER.debug(
+                "Climate Heating: %s HomeKit %s write failed, falling "
+                "back to cloud API",
+                self._zone_name, mode_label,
+            )
+        return local_success
+
+    async def _apply_optimistic_hvac_mode_write(
+        self, hvac_mode: HVACMode, hvac_action: HVACAction,
+    ) -> None:
+        """Apply optimistic mode/action state after a successful local HomeKit write.
+
+        Mirrors what api_call_with_rollback already does for the cloud
+        fallback path, so a HomeKit-local write doesn't leave the entity
+        showing the old mode until cloud verification fires (~20s later).
+        """
+        self._attr_hvac_mode = hvac_mode
+        self._attr_hvac_action = hvac_action
+        self._overlay_type = "MANUAL"  # type: ignore[assignment]
+        await set_optimistic_fields(
+            self, self.coordinator,
+            expected={"hvac_mode": hvac_mode, "hvac_action": hvac_action},
+        )
+        self.async_write_ha_state()
+        if self.coordinator.state_reconciler:
+            self.coordinator.state_reconciler.record_local_write(self._zone_id)
+        self._schedule_cloud_verification()
+
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new HVAC mode."""
         # A zone showing AUTO can still carry a TADO_MODE/TIMER overlay (mode is
@@ -974,46 +1089,7 @@ class TadoClimate(PerEntityAvailabilityMixin, CoordinatorEntity["TadoDataUpdateC
         client = self.coordinator.api_client
 
         if hvac_mode == HVACMode.HEAT:
-            # Local-first: try HomeKit write (only when overlay mode is Tado Default,
-            # because HomeKit writes don't carry termination info)
-            local_success = False
-            use_homekit = should_use_homekit_for_overlay(self.hass, self._zone_id, entry_id=self._entry_id)
-            write_tracker = self.coordinator.write_health_tracker
-            if (
-                use_homekit
-                and self.coordinator.homekit_provider
-                and self.coordinator.homekit_provider.is_connected
-                and write_tracker is not None
-                and write_tracker.should_try_homekit()
-            ):
-                import time as _time
-
-                self.coordinator._homekit_write_attempts += 1
-                t0 = _time.monotonic()
-                try:
-                    local_success = await self.coordinator.homekit_provider.set_hvac_mode(
-                        self._zone_id, 1,  # 1=Heat
-                    )
-                except Exception:
-                    _LOGGER.debug(
-                        "Climate Heating: %s HomeKit HEAT write raised "
-                        "an exception, falling back to cloud",
-                        self._zone_name, exc_info=True,
-                    )
-                elapsed_ms = (_time.monotonic() - t0) * 1000
-                self.coordinator._homekit_write_latency_sum += elapsed_ms
-                self.coordinator._homekit_write_latency_count += 1
-                if local_success:
-                    self.coordinator._homekit_write_successes += 1
-                else:
-                    write_tracker.record_failure()
-                    self.coordinator._homekit_write_fallbacks += 1
-                    _LOGGER.debug(
-                        "Climate Heating: %s HomeKit HEAT write failed "
-                        ", falling back to cloud API",
-                        self._zone_name,
-                    )
-
+            local_success = await self._try_homekit_hvac_mode_write(1, "HEAT")
             if local_success:
                 self.coordinator.record_homekit_write_saved(self._zone_id)
                 self._last_write_source = "homekit"
@@ -1021,7 +1097,11 @@ class TadoClimate(PerEntityAvailabilityMixin, CoordinatorEntity["TadoDataUpdateC
                     "Climate Heating: %s set to HEAT via HomeKit",
                     self._zone_name,
                 )
-                self._schedule_cloud_verification()
+
+                temp = self._attr_target_temperature or 20
+                self._attr_hvac_mode = HVACMode.HEAT
+                new_hvac_action = self._calculate_hvac_action(target_temp=temp)
+                await self._apply_optimistic_hvac_mode_write(HVACMode.HEAT, new_hvac_action)
                 return
 
             # Cloud fallback
@@ -1045,46 +1125,7 @@ class TadoClimate(PerEntityAvailabilityMixin, CoordinatorEntity["TadoDataUpdateC
             self._last_write_source = "cloud"
 
         elif hvac_mode == HVACMode.OFF:
-            # Local-first: try HomeKit write (only when overlay mode is Tado Default,
-            # because HomeKit writes don't carry termination info)
-            local_success = False
-            use_homekit = should_use_homekit_for_overlay(self.hass, self._zone_id, entry_id=self._entry_id)
-            write_tracker = self.coordinator.write_health_tracker
-            if (
-                use_homekit
-                and self.coordinator.homekit_provider
-                and self.coordinator.homekit_provider.is_connected
-                and write_tracker is not None
-                and write_tracker.should_try_homekit()
-            ):
-                import time as _time
-
-                self.coordinator._homekit_write_attempts += 1
-                t0 = _time.monotonic()
-                try:
-                    local_success = await self.coordinator.homekit_provider.set_hvac_mode(
-                        self._zone_id, 0,  # 0=Off
-                    )
-                except Exception:
-                    _LOGGER.debug(
-                        "Climate Heating: %s HomeKit OFF write raised "
-                        "an exception, falling back to cloud",
-                        self._zone_name, exc_info=True,
-                    )
-                elapsed_ms = (_time.monotonic() - t0) * 1000
-                self.coordinator._homekit_write_latency_sum += elapsed_ms
-                self.coordinator._homekit_write_latency_count += 1
-                if local_success:
-                    self.coordinator._homekit_write_successes += 1
-                else:
-                    write_tracker.record_failure()
-                    self.coordinator._homekit_write_fallbacks += 1
-                    _LOGGER.debug(
-                        "Climate Heating: %s HomeKit OFF write failed "
-                        ", falling back to cloud API",
-                        self._zone_name,
-                    )
-
+            local_success = await self._try_homekit_hvac_mode_write(0, "OFF")
             if local_success:
                 self.coordinator.record_homekit_write_saved(self._zone_id)
                 self._last_write_source = "homekit"
@@ -1092,7 +1133,8 @@ class TadoClimate(PerEntityAvailabilityMixin, CoordinatorEntity["TadoDataUpdateC
                     "Climate Heating: %s set to OFF via HomeKit",
                     self._zone_name,
                 )
-                self._schedule_cloud_verification()
+
+                await self._apply_optimistic_hvac_mode_write(HVACMode.OFF, HVACAction.OFF)
                 return
 
             # Cloud fallback

--- a/custom_components/tado_ce/state_reconciler.py
+++ b/custom_components/tado_ce/state_reconciler.py
@@ -6,6 +6,7 @@ from datetime import timedelta
 import logging
 from typing import TYPE_CHECKING, Any, Final
 
+from homeassistant.components.climate.const import HVACAction
 from homeassistant.util import dt as dt_util
 
 from .const import HOMEKIT_STALENESS_THRESHOLD
@@ -19,6 +20,16 @@ _LOGGER = logging.getLogger(__name__)
 # so the bridge's stale post-write read can't overwrite the user's
 # fresh setpoint.
 WRITE_PROTECTION_WINDOW: Final[timedelta] = timedelta(minutes=3)
+
+# HAP "Current Heating Cooling State" characteristic values (0=Off,
+# 1=Heat, 2=Cool). Maps to HVACAction.IDLE rather than OFF for 0: the
+# entity's hvac_mode already owns the OFF action, this only reports
+# whether the zone is actively calling for heat right now.
+_CURRENT_HEATING_STATE_TO_ACTION: Final[dict[int, HVACAction]] = {
+    0: HVACAction.IDLE,
+    1: HVACAction.HEATING,
+    2: HVACAction.COOLING,
+}
 
 
 class StateReconciler:
@@ -203,6 +214,25 @@ class StateReconciler:
 
         self._log_source_transition(zone_id, "target_temp", "cloud", cloud_value)
         return cloud_value, "cloud"
+
+    def get_zone_hvac_action(self, zone_id: str) -> HVACAction | None:
+        """Return the bridge's live current-heating-state as an HVACAction, or None.
+
+        Unlike temperature/target-temperature there's no cloud value to
+        negotiate against here (cloud only offers heating_power, which the
+        caller already falls back to), so a fresh local reading is used
+        outright. `freshness_mode="observed"` keeps this valid across the
+        periodic cache refresh even while the state itself hasn't changed,
+        the same way room-temperature stays fresh while stable.
+        """
+        local_val, is_fresh = self._get_fresh_local_value(zone_id, "get_hvac_state")
+        if not is_fresh or local_val is None:
+            return None
+        action = _CURRENT_HEATING_STATE_TO_ACTION.get(int(local_val))
+        if action is None:
+            return None
+        self._log_source_transition(zone_id, "hvac_action", "homekit", local_val)
+        return action
 
     def is_local_write_protected(self, zone_id: str) -> bool:
         """Return True while a recent local write protects this zone's value.


### PR DESCRIPTION
Three related bugs in the `tado_ce` custom component's HomeKit local-control path, all stemming from the same theme: writes and reads that go through the paired HomeKit bridge weren't fully wired into the existing optimistic-update and state-reconciliation machinery, so the UI either lagged far behind the real device state or, in one case, could silently revert a change the user just made. Also includes a small Lovelace dashboard change unrelated to the integration fixes.

## 1. `hvac_action` ("Heating"/"Idle") lagged reality by up to ~17s

### Issue
Changing a thermostat's target temperature (or mode) while in manual `HEAT` mode made the climate entity show `Heating` immediately, even when the new target was *below* the current room temperature and no call for heat was actually happening.

`_calculate_hvac_action()` in `climate_heating.py` unconditionally assumed `HEATING` whenever a target temperature was just set in `HEAT` mode (`climate_heating.py:192-193`, pre-fix), regardless of whether the new target was actually above the current room temperature. This optimistic guess persisted until the Tado cloud API confirmed otherwise, which could take up to `DEFAULT_OPTIMISTIC_WINDOW_SECONDS` (17s, `const.py:481`) plus a coordinator poll cycle.

Meanwhile, the integration already had everything needed to know the real answer *immediately*: with a HomeKit bridge paired, `HomeKitLocalProvider` subscribes to the bridge's `CHAR_CURRENT_HEATING_STATE` (`0x0F`) HAP characteristic and receives push events the moment the TRV/boiler's actual heating-call state changes (`homekit_provider.py:384-390`, `_on_event_callback`). That data was being collected into a cache but never read by anything — `HomeKitLocalProvider.get_hvac_state()` had no caller anywhere in the codebase.

### Fix
- **`state_reconciler.py`**: added `get_zone_hvac_action(zone_id)`, which reads the bridge's live current-heating-state via the existing (already subscribed) characteristic cache and maps it to an `HVACAction` (0→IDLE, 1→HEATING, 2→COOLING), following the same freshness-checking pattern already used for temperature/target-temperature merging.
- **`climate_heating.py`**: added `_get_local_hvac_action()`, and wired it into `_calculate_hvac_action()` as the top-priority source (after the `OFF`-mode short-circuit, before the optimistic guess). Also wired it into the real-time `_handle_homekit_update()` push handler so a genuine heating-state change from the bridge updates the entity within (typically) well under a second, instead of waiting for the optimistic window to expire or the next cloud poll.

Net effect: with HomeKit paired and connected, `Heating` now only shows when the TRV/bridge actually reports a call for heat. The old optimistic-guess behaviour remains as the fallback when HomeKit is unavailable.

## 2. Switching to `Heat`/`Off` mode took ~20s to reflect in the UI

### Issue
`async_set_temperature()` already applies an optimistic update (set the attrs, call `set_optimistic_fields`, `async_write_ha_state()`) *before* attempting the write, so target-temperature changes reflect instantly regardless of whether the write lands via HomeKit or falls back to cloud. The cloud-fallback mode-change path (`api_call_with_rollback` → `_attempt_with_rollback`, `climate_helpers.py:237-245`) does the same.

`async_set_hvac_mode()`'s **HomeKit-local** write path for `HEAT` and `OFF` did not. It wrote to the bridge, then just called `self._schedule_cloud_verification()` and returned — `_attr_hvac_mode`, `_attr_hvac_action`, and `async_write_ha_state()` were never touched. The entity only picked up the new mode once the deferred verification timer fired, `get_optimistic_window() + CLOUD_VERIFICATION_BUFFER_SECONDS` later (~19-20s).

### Fix
- **`climate_heating.py`**: both the `HEAT` and `OFF` local-write-success branches in `async_set_hvac_mode()` now apply the same optimistic-update pattern used everywhere else — set `_attr_hvac_mode` / `_attr_hvac_action` / `_overlay_type`, call `set_optimistic_fields(...)`, `async_write_ha_state()`, and `state_reconciler.record_local_write(...)` — immediately after a successful local write. The deferred `_schedule_cloud_verification()` call remains as the existing safety net in case the write silently failed.

Scope note: this intentionally does **not** make `_attr_hvac_mode` continuously track HomeKit's `target_heating_state` push (the way `hvac_action` now does in fix #1). There's a documented reason in the code: the Tado bridge has no HomeKit concept of "follow the schedule," so a schedule-driven `AUTO` zone that's currently calling for heat reports `Heat` over HomeKit — freely merging that into `_attr_hvac_mode` previously caused `AUTO` zones to flap to `Heat` mode. The optimistic-write fix above solves the reported lag without reopening that bug; `AUTO` transitions still rely on the cloud poll as before.

## 3. Target temperature could silently revert a few seconds after being set

### Issue
This surfaced while testing fix 2: switch to `Heat` mode, then change the target temperature — the entity briefly showed a heating call that didn't match the new (lower) target, the new temperature never appeared in the Tado app, and after a few seconds Home Assistant reverted the displayed temperature back to the old value.

Root cause: `_execute_set_temp_api()` — the code path used for every temperature change written via HomeKit — was the **only** successful-write path in the entire integration that never called `state_reconciler.record_local_write(zone_id)`. Every other write path does: cloud writes via `_attempt_with_rollback` (`climate_helpers.py:280`), the HEAT/OFF HomeKit mode writes from fix 2, and `climate_ac.py`'s cloud writes.

That call stamps a 3-minute "write protection window" (`WRITE_PROTECTION_WINDOW`, `state_reconciler.py`) that tells `merge_zone_target_temperature()` to trust the value just written locally over anything the bridge reports afterward. Without it, as soon as the entity's (much shorter) freshness-debounce window lapsed, any conflicting value the bridge echoed back — plausible right after a mode switch, since the TRV may not have fully applied the new mode before the temperature write landed — was accepted as truth, silently reverting the just-set target. `_calculate_hvac_action()` then correctly reported `Heating` relative to the reverted (old, still-current-on-device) target, which is what looked like a bogus heating call.

The same gap existed in `climate_ac.py`'s HomeKit-write-success branch for AC target-temperature writes, even though the comment on the adjacent cloud-success branch explicitly documents why the stamp is needed.

### Fix
- **`climate_heating.py`**: added `state_reconciler.record_local_write(zone_id)` to the HomeKit-success branch of `_execute_set_temp_api()`.
- **`climate_ac.py`**: added the same call to the equivalent HomeKit temperature-write success branch.

---

## Files changed

- `custom_components/tado_ce/state_reconciler.py`
- `custom_components/tado_ce/climate_heating.py`
- `custom_components/tado_ce/climate_ac.py`
