### PR TITLE
Keep entities live on HomeKit when the quota reserve pauses polling

### DIFF
--- a/custom_components/tado_ce/coordinator.py
+++ b/custom_components/tado_ce/coordinator.py
@@ -281,8 +281,12 @@ class TadoDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """Return True when HomeKit local provider is wired and currently connected."""
         return self.homekit_provider is not None and self.homekit_provider.is_connected
 
-    def _log_cloud_unavailable(self, exc: Exception) -> None:
-        """Log INFO on the first cloud→unreachable transition (idempotent)."""
+    def _log_cloud_unavailable(self, exc: Exception | str) -> None:
+        """Log INFO on the first cloud→unreachable transition (idempotent).
+
+        Accepts a plain reason string as well, so the pre-emptive quota
+        pause can reuse it without inventing an exception.
+        """
         if not self._cloud_unavailable_logged:
             _LOGGER.info(
                 "Coordinator: Tado cloud unreachable (%s), keeping "
@@ -647,6 +651,16 @@ class TadoDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 _LOGGER.warning("Coordinator: %s", reason)
                 self._was_paused = True
                 self.update_interval = timedelta(minutes=15)
+                if self.is_homekit_active:
+                    # The local provider is still serving this home, so the
+                    # zones keep updating without spending a cloud call.
+                    # Raising UpdateFailed here would mark every
+                    # CoordinatorEntity unavailable for the whole quota
+                    # window; hold the last cloud snapshot instead and let
+                    # StateReconciler merge fresh local values over it, the
+                    # same way the TadoRateLimitError handler below does.
+                    self._log_cloud_unavailable(reason)
+                    return self.data or {}
                 # retry_after lets HA defer the next refresh precisely.
                 reset_seconds = self._cached_ratelimit.get("reset_seconds")
                 retry_after = _sanitize_retry_after(reset_seconds)

--- a/custom_components/tado_ce/coordinator.py
+++ b/custom_components/tado_ce/coordinator.py
@@ -651,7 +651,7 @@ class TadoDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 _LOGGER.warning("Coordinator: %s", reason)
                 self._was_paused = True
                 self.update_interval = timedelta(minutes=15)
-                if self.is_homekit_active:
+                if self.is_homekit_active and self.data:
                     # The local provider is still serving this home, so the
                     # zones keep updating without spending a cloud call.
                     # Raising UpdateFailed here would mark every
@@ -659,8 +659,13 @@ class TadoDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     # window; hold the last cloud snapshot instead and let
                     # StateReconciler merge fresh local values over it, the
                     # same way the TadoRateLimitError handler below does.
+                    #
+                    # `self.data` is falsy until the first successful poll,
+                    # so a cold start during a pause still raises and lets
+                    # async_config_entry_first_refresh retry via
+                    # ConfigEntryNotReady rather than coming up empty.
                     self._log_cloud_unavailable(reason)
-                    return self.data or {}
+                    return self.data
                 # retry_after lets HA defer the next refresh precisely.
                 reset_seconds = self._cached_ratelimit.get("reset_seconds")
                 retry_after = _sanitize_retry_after(reset_seconds)


### PR DESCRIPTION
Fixes #340.

> **Note:** this PR was written by Claude, an AI model, working on behalf of @nicohabets, from a real installation of his that hit this. The reasoning is spelled out below so it can be judged on its merits rather than taken on trust.

## The problem

`_async_update_data()` can lose the cloud in two ways, and only one of them consults HomeKit.

The reactive path (`TadoRateLimitError`, and `TadoSyncError` next to it) already does the right thing:

```python
if self.is_homekit_active:
    self._log_cloud_unavailable(e)
    return self.data or {}
raise UpdateFailed(...)
```

The pre-emptive reserve guard at the top of the same method did not: it raised `UpdateFailed` unconditionally, and `homekit_connected` was computed on the statement immediately after that `raise`. `UpdateFailed` sets `last_update_success = False`, so every `CoordinatorEntity` reports `available = False` for the entire quota window, with the bridge connected and every zone mapped.

Since the guard is designed to trip before the API ever returns a 429, this is the path most installs actually take to the end of a quota window, so in practice the local fallback rarely gets a chance to run.

## The change

Check `is_homekit_active` in the pause branch as well, and hold the last cloud snapshot instead of failing the refresh. `_log_cloud_unavailable()` gains `| str` on its parameter so the branch can pass `reason` without inventing an exception.

This is not a stale-data workaround: `climate_heating.py` runs `StateReconciler` on every coordinator update with the priority chain external > homekit-if-fresh > cloud, so with the provider connected the displayed temperature and target keep tracking the bridge.

Without HomeKit the behaviour is unchanged: same `UpdateFailed`, same `retry_after`. `self._was_paused` still becomes `True` on this path so the existing resume transition keeps working, and `update_interval` is still pinned to 15 minutes.

## Checks

- `python3.13 -m py_compile custom_components/tado_ce/coordinator.py` clean
- `ruff check --target-version py313 custom_components/tado_ce/coordinator.py` clean
- Not runtime-tested against live quota exhaustion. The reporting install is mid-window and burning the remaining reserve to reproduce it on purpose seemed the wrong trade; happy to confirm behaviour on the next window if that is useful.

Glad to reshape this if you would rather gate it behind an option, log it at a different level, or handle the reserve case somewhere else entirely.